### PR TITLE
fix: replays always try to create folder

### DIFF
--- a/OBS-RecORDER.py
+++ b/OBS-RecORDER.py
@@ -409,8 +409,9 @@ class File:
             os.makedirs(self.newFolder)
 
         if self.isReplay is True:
-            self.newFolder = self.newFolder + "\\" + self.replaysFolderName
-            os.makedirs(self.newFolder)
+            if not os.path.exists(self.newFolder):
+                self.newFolder = self.newFolder + "\\" + self.replaysFolderName
+                os.makedirs(self.newFolder)
 
     def remember_and_move(self) -> None:
         """Remembers the previous location of the file and moves it to a new one"""


### PR DESCRIPTION
"create_new_folder" function of File class was always trying to create a new folder each time the replay was saved.